### PR TITLE
fix: improve WASM loading with better error handling

### DIFF
--- a/packages/editor-cljs/src/lexicon/core.cljs
+++ b/packages/editor-cljs/src/lexicon/core.cljs
@@ -9,32 +9,40 @@
 (defn load-wasm-module
   "Asynchronously load the WebAssembly module"
   []
-  ;; Create a script tag to load the WASM module
-  (let [script (.createElement js/document "script")]
-    (set! (.-src script) "./lexicon-engine/wasm/pkg/lexicon_wasm.js")
-    (set! (.-type script) "module")
-    (set! (.-onload script)
-          (fn []
-            (try
-              ;; Access the globally available module
-              (if (exists? js/wasm_bindgen)
-                (-> (js/wasm_bindgen "./lexicon-engine/wasm/pkg/lexicon_wasm_bg.wasm")
-                    (.then (fn []
-                             ;; Create a WasmEditorCore instance with initial content
-                             (let [wasm-instance (js/WasmEditorCore.)]
-                               (.init wasm-instance "")
-                               ;; Store in re-frame db
-                               (rf/dispatch [:wasm-module-loaded wasm-instance])
-                               (println "✅ WASM module loaded and initialized"))))
-                    (.catch (fn [error]
-                              (println "❌ Failed to initialize WASM:" error))))
-                (println "❌ WASM bindgen not available"))
-              (catch js/Error error
-                (println "❌ Failed to load WASM module:" error)))))
-    (set! (.-onerror script)
-          (fn [error]
-            (println "❌ Failed to load WASM script:" error)))
-    (.appendChild (.-head js/document) script)))
+  (try
+    (println "🔍 Loading WASM module...")
+    ;; Try to load the WASM module using dynamic import via fetch
+    (-> (js/fetch "./lexicon-engine/wasm/pkg/lexicon_wasm.js")
+        (.then (fn [response]
+                 (if (.-ok response)
+                   (.text response)
+                   (throw (js/Error. (str "Failed to fetch WASM JS: " (.-status response)))))))
+        (.then (fn [js-code]
+                 ;; Execute the WASM JavaScript code
+                 (js/eval js-code)
+                 ;; Now try to initialize
+                 (if (exists? js/wasm_bindgen)
+                   (-> (js/wasm_bindgen "./lexicon-engine/wasm/pkg/lexicon_wasm_bg.wasm")
+                       (.then (fn []
+                                (println "✅ WASM bindgen initialized")
+                                ;; Check if WasmEditorCore is available
+                                (if (exists? js/WasmEditorCore)
+                                  (let [wasm-instance (js/WasmEditorCore.)]
+                                    (println "✅ WasmEditorCore created")
+                                    (.init wasm-instance "")
+                                    (rf/dispatch [:wasm-module-loaded wasm-instance])
+                                    (println "✅ WASM module loaded and initialized"))
+                                  (throw (js/Error. "WasmEditorCore not available after WASM load")))))
+                       (.catch (fn [error]
+                                 (println "❌ Failed to initialize WASM bindgen:" error)
+                                 (rf/dispatch [:wasm-load-failed error]))))
+                   (throw (js/Error. "wasm_bindgen function not available after loading JS")))))
+        (.catch (fn [error]
+                  (println "❌ Failed to load WASM module:" error)
+                  (rf/dispatch [:wasm-load-failed error]))))
+    (catch js/Error error
+      (println "❌ Failed to start WASM loading:" error)
+      (rf/dispatch [:wasm-load-failed error]))))
 
 (defn mount-app
   "Mount the main application component"

--- a/packages/editor-cljs/src/lexicon/events.cljs
+++ b/packages/editor-cljs/src/lexicon/events.cljs
@@ -388,6 +388,15 @@
        ;; Buffer not found - no action needed
        {:db db}))))
 
+;; -- WASM Loading Error Events --
+
+(rf/reg-event-db
+ :wasm-load-failed
+ (fn [db [_ error]]
+   "Handle WASM loading failure"
+   (println "WASM load failed, showing error to user:" error)
+   (assoc-in db [:system :wasm-error] (str error))))
+
 ;; -- Region Selection and Kill Ring Events --
 
 (rf/reg-event-db

--- a/packages/editor-cljs/src/lexicon/subs.cljs
+++ b/packages/editor-cljs/src/lexicon/subs.cljs
@@ -203,3 +203,9 @@
  (fn [[initialized? buffer] _]
    "Check if the editor is ready for user interaction"
    (and initialized? buffer)))
+
+(rf/reg-sub
+ :wasm-error
+ (fn [db _]
+   "Get WASM loading error if any"
+   (get-in db [:system :wasm-error])))

--- a/packages/editor-cljs/src/lexicon/views.cljs
+++ b/packages/editor-cljs/src/lexicon/views.cljs
@@ -301,7 +301,8 @@
   "Main application component"
   []
   (let [initialized? @(rf/subscribe [:initialized?])
-        editor-ready? @(rf/subscribe [:editor-ready?])]
+        editor-ready? @(rf/subscribe [:editor-ready?])
+        wasm-error @(rf/subscribe [:wasm-error])]
     
     [:div.lexicon-app
      {:style {:width "100%"
@@ -310,6 +311,24 @@
               :flex-direction "column"}}
      
      (cond
+       wasm-error
+       [:div.error
+        {:style {:padding "20px"
+                 :color "#ff6b6b"
+                 :background-color "#2d1b1b"
+                 :border "1px solid #ff6b6b"
+                 :border-radius "4px"
+                 :margin "20px"
+                 :font-family "monospace"}}
+        [:h3 "WASM Loading Error"]
+        [:p "Failed to load the WebAssembly module:"]
+        [:pre {:style {:background-color "#1a1a1a"
+                       :padding "10px"
+                       :border-radius "4px"
+                       :overflow-x "auto"}}
+         (str wasm-error)]
+        [:p "Please check the browser console for more details."]]
+       
        (not initialized?)
        [loading-view]
        


### PR DESCRIPTION
- Replace script tag loading with fetch + eval approach
- Add comprehensive error reporting for WASM loading failures
- Add :wasm-load-failed event and :wasm-error subscription
- Show detailed error messages in UI when WASM fails to load
- Should resolve 'WASM bindgen not available' issue